### PR TITLE
Add support for GDAL 2.0.

### DIFF
--- a/src/ogr_include.hpp
+++ b/src/ogr_include.hpp
@@ -31,6 +31,7 @@
 # pragma GCC diagnostic pop
 #endif
 
+#if GDAL_VERSION_MAJOR < 2
 struct OGRDataSourceDestroyer {
     void operator()(OGRDataSource* ptr) {
         if (ptr) {
@@ -38,5 +39,14 @@ struct OGRDataSourceDestroyer {
         }
     }
 };
+#else
+struct GDALDatasetDestroyer {
+    void operator()(GDALDataset* ptr) {
+        if (ptr) {
+            GDALClose(ptr);
+        }
+    }
+};
+#endif
 
 #endif // OGR_INCLUDE_HPP

--- a/src/output_database.hpp
+++ b/src/output_database.hpp
@@ -51,7 +51,11 @@ class OutputDatabase {
 
     bool m_with_index;
 
+#if GDAL_VERSION_MAJOR < 2
     std::unique_ptr<OGRDataSource, OGRDataSourceDestroyer> m_data_source;
+#else
+    std::unique_ptr<GDALDataset, GDALDatasetDestroyer> m_data_source;
+#endif
 
     std::unique_ptr<LayerErrorPoints> m_layer_error_points;
     std::unique_ptr<LayerErrorLines>  m_layer_error_lines;

--- a/src/output_layers.cpp
+++ b/src/output_layers.cpp
@@ -47,7 +47,11 @@ void Layer::commit() {
 
 /***************************************************************/
 
+#if GDAL_VERSION_MAJOR < 2
 LayerErrorPoints::LayerErrorPoints(OGRDataSource* data_source, const char** options) :
+#else
+LayerErrorPoints::LayerErrorPoints(GDALDataset* data_source, const char** options) :
+#endif
     Layer() {
     m_layer = data_source->CreateLayer("error_points", srs.out(), wkbPoint, const_cast<char**>(options));
     if (!m_layer) {
@@ -91,7 +95,11 @@ void LayerErrorPoints::add(OGRPoint* point, const char* error, osmium::object_id
 
 /***************************************************************/
 
+#if GDAL_VERSION_MAJOR < 2
 LayerErrorLines::LayerErrorLines(OGRDataSource* data_source, const char** options) :
+#else
+LayerErrorLines::LayerErrorLines(GDALDataset* data_source, const char** options) :
+#endif
     Layer() {
     m_layer = data_source->CreateLayer("error_lines", srs.out(), wkbLineString, const_cast<char**>(options));
     if (!m_layer) {
@@ -135,7 +143,11 @@ void LayerErrorLines::add(OGRLineString* linestring, const char* error, osmium::
 
 /***************************************************************/
 
+#if GDAL_VERSION_MAJOR < 2
 LayerRings::LayerRings(OGRDataSource* data_source, const char** options) :
+#else
+LayerRings::LayerRings(GDALDataset* data_source, const char** options) :
+#endif
     Layer() {
     m_layer = data_source->CreateLayer("rings", srs.out(), wkbPolygon, const_cast<char**>(options));
     if (!m_layer) {
@@ -264,7 +276,11 @@ void LayerRings::add(OGRPolygon* polygon, int osm_id, int nways, int npoints, bo
 
 /***************************************************************/
 
+#if GDAL_VERSION_MAJOR < 2
 LayerPolygons::LayerPolygons(OGRDataSource* data_source, const char** options, const char* name) :
+#else
+LayerPolygons::LayerPolygons(GDALDataset* data_source, const char** options, const char* name) :
+#endif
     Layer(),
     m_name(name) {
     m_layer = data_source->CreateLayer(name, srs.out(), wkbPolygon, const_cast<char**>(options));
@@ -293,7 +309,11 @@ void LayerPolygons::add(OGRPolygon* polygon) {
 
 /***************************************************************/
 
+#if GDAL_VERSION_MAJOR < 2
 LayerLines::LayerLines(OGRDataSource* data_source, const char** options) :
+#else
+LayerLines::LayerLines(GDALDataset* data_source, const char** options) :
+#endif
     Layer() {
     m_layer = data_source->CreateLayer("lines", srs.out(), wkbLineString, const_cast<char**>(options));
     if (!m_layer) {

--- a/src/output_layers.hpp
+++ b/src/output_layers.hpp
@@ -29,7 +29,11 @@
 extern SRS srs;
 
 class OGRLayer;
+#if GDAL_VERSION_MAJOR < 2
 class OGRDataSource;
+#else
+class GDALDataset;
+#endif
 class OGRPoint;
 class OGRLineString;
 class OGRPolygon;
@@ -60,7 +64,11 @@ class LayerErrorPoints : public Layer {
 
 public:
 
+#if GDAL_VERSION_MAJOR < 2
     LayerErrorPoints(OGRDataSource* data_source, const char** options);
+#else
+    LayerErrorPoints(GDALDataset* data_source, const char** options);
+#endif
     void add(OGRPoint* point, const char* error, osmium::object_id_type id);
 
 };
@@ -72,7 +80,11 @@ class LayerErrorLines : public Layer {
 
 public:
 
+#if GDAL_VERSION_MAJOR < 2
     LayerErrorLines(OGRDataSource* data_source, const char** options);
+#else
+    LayerErrorLines(GDALDataset* data_source, const char** options);
+#endif
     void add(OGRLineString* linestring, const char* error, osmium::object_id_type id);
 
 };
@@ -88,7 +100,11 @@ class LayerRings : public Layer {
 
 public:
 
+#if GDAL_VERSION_MAJOR < 2
     LayerRings(OGRDataSource* data_source, const char** options);
+#else
+    LayerRings(GDALDataset* data_source, const char** options);
+#endif
     void add(OGRPolygon* polygon, int id, int nways, int npoints, bool fixed, LayerErrorPoints* layer_error_points);
 
 };
@@ -103,7 +119,11 @@ class LayerPolygons : public Layer {
 
 public:
 
+#if GDAL_VERSION_MAJOR < 2
     LayerPolygons(OGRDataSource* data_source, const char** options, const char* name);
+#else
+    LayerPolygons(GDALDataset* data_source, const char** options, const char* name);
+#endif
     void add(OGRPolygon* polygon);
 
 };
@@ -116,7 +136,11 @@ class LayerLines : public Layer {
 
 public:
 
+#if GDAL_VERSION_MAJOR < 2
     LayerLines(OGRDataSource* data_source, const char** options);
+#else
+    LayerLines(GDALDataset* data_source, const char** options);
+#endif
     void add(OGRLineString* lines);
 
 };


### PR DESCRIPTION
As reported in #15, osmcoastline fails to build with GDAL 2.0

This PR forwards the changes added to the Debian package to build successfully with GDAL 2.0.1.

The code is kept as-is for GDAL 1.x, and alternatives are added for GDAL 2.x to build successfully with both.