### PR TITLE
Add "ESRI Shapefile driver" as a command line option in addition to "SQLite driver"

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ options.
 
 ## Output
 
-The output is a spatialite database with the following tables. All tables are
-always created but depending on the command line options only some of them
-might contain anything.
+By default, the output is a spatialite database with the following tables. All
+tables are always created but depending on the command line options only some of
+them might contain anything.
 
 * `error_lines` Lines that have errors (for instance not closed rings or
   self-intersections).
@@ -145,10 +145,7 @@ By default all output is in WGS84. You can use the option `--srs=3857` to
 create output in "Web Mercator". (Other projections are currently not
 supported.)
 
-OSMCoastline always creates only this one database. If you need shapefiles
-use ogr2ogr to convert the data:
 
-    ogr2ogr -f "ESRI Shapefile" land_polygons.shp coastline.db land_polygons
 
 By default geometry indexes are created for all tables. This makes the database
 larger, but faster to use. You can use the option `--no-index` to suppress
@@ -163,6 +160,16 @@ using Spatialite or PostGIS, respectively.
 The database tables `options` and `meta` contain the command line options
 used to create the database and some metadata. You can use the script
 `osmcoastline_readmeta` to look at them.
+
+By default, OSMCoastline creates a spatialite database. If you need shapefiles use
+ogr2ogr to convert the data:
+
+    ogr2ogr -f "ESRI Shapefile" land_polygons.shp coastline.db land_polygons
+
+Alternatively, OSMCoastline aims to support all geospatial data formats as the output
+(e.g. shapefile, by setting GDAL driver as "ESRI Shapefile"). If a data format other
+than spatialite database is selected as the output format, the two database tables
+`options` and `meta` will be omitted and geometry indexes will not be created. 
 
 
 ## Steps

--- a/man/osmcoastline.md
+++ b/man/osmcoastline.md
@@ -49,6 +49,10 @@ description of the options below and the README.md for details.
 -f, --overwrite
 :   Overwrite output file if it already exists.
 
+-g, --gdal-driver=DRIVER
+:   Allows user to select any GDAL driver, but only "SQLite" and "ESRI Shapefile"
+    GDAL drivers have been tested. The default is "SQLite". 
+
 -i, --no-index
 :   Do not create spatial indexes in output db. The default is to create those
     indexes. This makes the database larger, but data access is faster.

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -43,10 +43,11 @@ static void print_help() {
               << "  -i, --no-index             - Do not create spatial indexes in output db\n"
               << "  -d, --debug                - Enable debugging output\n"
               << "  -f, --overwrite            - Overwrite output file if it already exists\n"
+              << "  -g, --gdal-driver=DRIVER   - GDAL driver (SQLite or ESRI Shapefile)\n"
               << "  -l, --output-lines         - Output coastlines as lines to database file\n"
               << "  -m, --max-points=NUM       - Split lines/polygons with more than this many\n"
               << "                               points (0 - disable splitting)\n"
-              << "  -o, --output-database=FILE - Spatialite database file for output\n"
+              << "  -o, --output-database=FILE - Database file for output\n"
               << "  -p, --output-polygons=land|water|both|none\n"
               << "                             - Which polygons to write out (default: land)\n"
               << "  -r, --output-rings         - Output rings to database file\n"
@@ -83,6 +84,7 @@ Options::Options(int argc, char* argv[]) {
         {"close-distance",  required_argument, nullptr, 'c'},
         {"no-index",              no_argument, nullptr, 'i'},
         {"debug",                 no_argument, nullptr, 'd'},
+        {"gdal-driver",     required_argument, nullptr, 'g'},
         {"help",                  no_argument, nullptr, 'h'},
         {"output-lines",          no_argument, nullptr, 'l'},
         {"max-points",      required_argument, nullptr, 'm'},
@@ -98,7 +100,7 @@ Options::Options(int argc, char* argv[]) {
     };
 
     while (true) {
-        const int c = getopt_long(argc, argv, "b:c:idhlm:o:p:rfs:S:vV", long_options, nullptr);
+        const int c = getopt_long(argc, argv, "b:c:idg:hlm:o:p:rfs:S:vV", long_options, nullptr);
         if (c == -1) {
             break;
         }
@@ -123,6 +125,9 @@ Options::Options(int argc, char* argv[]) {
             case 'h':
                 print_help();
                 std::exit(return_code_ok);
+            case 'g':
+                driver = optarg;
+                break;
             case 'l':
                 output_lines = true;
                 break;

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -57,6 +57,9 @@ struct Options {
     /// Show debug output?
     bool debug = false;
 
+    /// GDAL driver.
+    std::string driver = "SQLite";
+
     /// Maximum number of points in polygons.
     int max_points_in_polygon = 1000;
 
@@ -66,7 +69,7 @@ struct Options {
     /// What polygons should be written out?
     output_polygon_type output_polygons = output_polygon_type::land;
 
-    /// Output Spatialite database file name.
+    /// Output database file name.
     std::string output_database;
 
     /// Should output database be overwritten

--- a/src/output_database.hpp
+++ b/src/output_database.hpp
@@ -39,11 +39,13 @@ struct Options;
 struct Stats;
 
 /**
- * Handle output to an sqlite database (via OGR).
+ * Handle output to a database (via OGR).
  * Several tables/layers are created using the right SRS for the different
  * kinds of data.
  */
 class OutputDatabase {
+
+    std::string m_driver;
 
     bool m_with_index;
 
@@ -77,9 +79,11 @@ class OutputDatabase {
 
     std::vector<std::string> layer_options() const;
 
+    std::vector<std::string> driver_options() const;
+
 public:
 
-    OutputDatabase(const std::string& outdb, SRS& srs, bool with_index=false);
+    OutputDatabase(const std::string& driver, const std::string& outdb, SRS& srs, bool with_index=false);
 
     ~OutputDatabase() noexcept = default;
 

--- a/test/t/gdal-driver-shapefile.sh
+++ b/test/t/gdal-driver-shapefile.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+#-----------------------------------------------------------------------------
+#
+#  Select ESRI Shapefile as the GDAL driver, and output data format.
+#
+#-----------------------------------------------------------------------------
+
+. $1/test/init.sh
+
+set -x
+
+#-----------------------------------------------------------------------------
+
+cat <<'OSM' >$INPUT
+n100 v1 x1.01 y1.01
+n101 v1 x1.04 y1.01
+n102 v1 x1.04 y1.04
+n103 v1 x1.01 y1.04
+w200 v1 Tnatural=coastline Nn100,n101,n102,n103,n100
+OSM
+
+#-----------------------------------------------------------------------------
+
+set -e
+
+rm -rf $DB
+
+$OSMC --verbose --overwrite --gdal-driver "ESRI Shapefile" --output-database=$DB $INPUT >$LOG 2>&1
+
+test $? -eq 0
+
+grep 'Turned 0 polygons around.$' $LOG
+
+grep '^There were 0 warnings.$' $LOG
+grep '^There were 0 errors.$' $LOG
+
+test -d $DB
+test -f $DB/land_polygons.dbf
+test -f $DB/land_polygons.prj
+test -f $DB/land_polygons.shp
+test -f $DB/land_polygons.shx
+
+#-----------------------------------------------------------------------------


### PR DESCRIPTION
This pull request is related to this [issue](https://github.com/osmcode/osmcoastline/issues/35).

Test plan: 
`./osmcoastline -o test.db -v  ~/Downloads/hawaii-latest.osm.pbf`
`./osmcoastline -o test_shapefile -v -g "ESRI Shapefile" ~/Downloads/hawaii-latest.osm.pbf`
`./osmcoastline -o test.db -v  ~/Downloads/rhode-island-latest.osm.pbf`
`./osmcoastline -o test_shapefile -v -g "ESRI Shapefile" ~/Downloads/rhode-island-latest.osm.pbf`
All commands run as expected. 

My opinion on "supporting all GDAL drivers"
I have tested a few GDAL drivers such as GEOJSON, OpenFileGDB, OSM, and all of them return errors for various reasons. For example, GeoJSON driver doesn't support creating more than one layer, while OSM driver does not support the GDALDriver::Create() operation. As a result, "supporting all GDAL drivers" requires a significant amount of code changes. By adding support only for "ESRI Shapefile", we are adding value to osmcoastline without too much additional work. 