### PR TITLE
Fix compatibility with GDAL 3.7.

### DIFF
--- a/src/coastline_polygons.cpp
+++ b/src/coastline_polygons.cpp
@@ -254,7 +254,11 @@ void CoastlinePolygons::output_land_polygons(bool make_copy) {
     }
 }
 
+#if (GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,7,0))
+void CoastlinePolygons::add_line_to_output(std::unique_ptr<OGRLineString> line, const OGRSpatialReference* srs) const {
+#else
 void CoastlinePolygons::add_line_to_output(std::unique_ptr<OGRLineString> line, OGRSpatialReference* srs) const {
+#endif
     line->setCoordinateDimension(2);
     line->assignSpatialReference(srs);
     m_output.add_line(std::move(line));

--- a/src/coastline_polygons.hpp
+++ b/src/coastline_polygons.hpp
@@ -78,7 +78,11 @@ class CoastlinePolygons {
 
     std::pair<std::unique_ptr<OGRPolygon>, std::unique_ptr<OGRPolygon>> split_envelope(const OGREnvelope& envelope, int level, int num_points) const;
 
+#if (GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,7,0))
+    void add_line_to_output(std::unique_ptr<OGRLineString> line, const OGRSpatialReference* srs) const;
+#else
     void add_line_to_output(std::unique_ptr<OGRLineString> line, OGRSpatialReference* srs) const;
+#endif
     void output_polygon_ring_as_lines(int max_points, const OGRLinearRing* ring) const;
 
 public:


### PR DESCRIPTION
As documented in [MIGRATION_GUIDE.TXT](https://github.com/OSGeo/gdal/blob/release/3.7/MIGRATION_GUIDE.TXT#L40):
> - OGRGeometry::getSpatialReference() now returns a const OGRSpatialReference*

Fixes: #44